### PR TITLE
Add PHP8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     ],
 
     "require": {
-        "php":                              "^7.0",
-        "guzzlehttp/guzzle":                "~6.0|~7.0",
+        "php":                              "^7.0 || ^8.0",
+        "guzzlehttp/guzzle":                "~6.0 || ^7.5.0",
         "eightpoints/guzzle-bundle":        "~8.0",
-        "symfony/http-kernel":              "~4.0|~5.0",
-        "symfony/config":                   "~4.0|~5.0",
-        "symfony/dependency-injection":     "~4.0|~5.0",
-        "symfony/expression-language":      "~4.0|~5.0",
+        "symfony/http-kernel":              "~4.0 || ~5.0",
+        "symfony/config":                   "~4.0 || ~5.0",
+        "symfony/dependency-injection":     "~4.0 || ~5.0",
+        "symfony/expression-language":      "~4.0 || ~5.0",
         "kevinrob/guzzle-cache-middleware": "~3.0"
     },
 

--- a/src/Event/InvalidateRequestEvent.php
+++ b/src/Event/InvalidateRequestEvent.php
@@ -67,7 +67,7 @@ if (is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
             $baseUri = $this->client->getConfig('base_uri');
 
             if ($baseUri instanceof UriInterface) {
-                $uri = Psr7\UriResolver::resolve($baseUri, Psr7\uri_for($this->uri));
+                $uri = Psr7\UriResolver::resolve($baseUri, Psr7\Utils::uriFor($this->uri));
             } else {
                 $uri = $this->uri;
             }
@@ -131,7 +131,7 @@ if (is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
             $baseUri = $this->client->getConfig('base_uri');
 
             if ($baseUri instanceof UriInterface) {
-                $uri = Psr7\UriResolver::resolve($baseUri, Psr7\uri_for($this->uri));
+                $uri = Psr7\UriResolver::resolve($baseUri, Psr7\Utils::uriFor($this->uri));
             } else {
                 $uri = $this->uri;
             }

--- a/tests/Event/InvalidateRequestEventTest.php
+++ b/tests/Event/InvalidateRequestEventTest.php
@@ -12,7 +12,7 @@ class InvalidateRequestEventTest extends TestCase
 {
     public function testGeneralUseCase()
     {
-        $baseUri = Psr7\uri_for('http://api.domain.tld');
+        $baseUri = Psr7\Utils::uriFor('http://api.domain.tld');
 
         /** @var Client|\PHPUnit_Framework_MockObject_MockObject $client */
         $client = $this->getMockBuilder(Client::class)->getMock();

--- a/tests/EventListener/InvalidateRequestSubscriberTest.php
+++ b/tests/EventListener/InvalidateRequestSubscriberTest.php
@@ -55,7 +55,7 @@ class InvalidateRequestSubscriberTest extends TestCase
 
     public function testGetSubscribedEventsResultType()
     {
-        $this->assertInternalType('array', InvalidateRequestSubscriber::getSubscribedEvents());
+        $this->assertIsArray(InvalidateRequestSubscriber::getSubscribedEvents());
     }
 
     public function testGetSubscribedEventsHasInvalidateEvent()

--- a/tests/GuzzleBundleCachePluginTest.php
+++ b/tests/GuzzleBundleCachePluginTest.php
@@ -19,7 +19,7 @@ class GuzzleBundleCachePluginTest extends TestCase
     /** @var GuzzleBundleCachePlugin */
     protected $plugin;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR will allow PHP 8 compatiblity. 
Additionally, the deprecated/removed PhpUnit method `assertInternalType` was fixed  and `Psr7\Utils::uriFor()` is used instead of the deprecated/removed `Psr7\uri_for()`.